### PR TITLE
Make the console scroll automatically

### DIFF
--- a/src/main/webapp/css/turtle-roy.css
+++ b/src/main/webapp/css/turtle-roy.css
@@ -117,7 +117,7 @@ input:focus {
   outline:none;
 }
 
-.console {
+.jquery-console-inner {
   padding: 1em 0em;
   background-color: #002b36;
   width: 900px; height: 200px;


### PR DESCRIPTION
The console should scroll down automatically when you enter new commands, and jquery-console supports this when the right element has `overflow: auto`.
