### PR TITLE
Make help overlay more likely to fit the screen

### DIFF
--- a/public/css/turtle-roy.css
+++ b/public/css/turtle-roy.css
@@ -78,18 +78,25 @@ body.embedded {
     width:100%;
     background: #000;
     display: none;
+    overflow: hidden;
 }
 
 #cheatsheet {
-  width: 1200px;
-  padding: 30px; 
+  position: absolute;
+  top: 50px;
+  bottom: 50px;
+  left: 50px;
+  right: 50px;
+  overflow: scroll;
+  padding: 30px;
   display:none;
+
   background: #FFF;
-  border-radius: 5px; 
-  -moz-border-radius: 5px; 
+  border-radius: 5px;
+  -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
-  box-shadow: 0px 0px 4px rgba(0,0,0,0.7); 
-  -webkit-box-shadow: 0 0 4px rgba(0,0,0,0.7); 
+  box-shadow: 0px 0px 4px rgba(0,0,0,0.7);
+  -webkit-box-shadow: 0 0 4px rgba(0,0,0,0.7);
   -moz-box-shadow: 0 0px 4px rgba(0,0,0,0.7);
 }
 
@@ -258,7 +265,7 @@ input:focus {
   height:100%;
   display:none;
   overflow:auto;
-}    
+}
 /* The console container element */
 .console {
   width: 100%;

--- a/public/lib/jquery.leanModal.js
+++ b/public/lib/jquery.leanModal.js
@@ -1,62 +1,53 @@
 (function($){
- 
-    $.fn.extend({ 
-         
+
+    $.fn.extend({
+
         leanModal: function(options) {
- 
+
             var defaults = {
-                top: 100,
                 overlay: 0.5,
                 closeButton: null
-            }
-            
+            };
+
             var overlay = $("<div id='lean_overlay'></div>");
-            
+
             $("body").append(overlay);
-                 
+
             options =  $.extend(defaults, options);
- 
+
             return this.each(function() {
-            
+
                 var o = options;
-               
+
                 $(this).click(function(e) {
-              
+
               	var modal_id = $(this).attr("href");
 
-				$("#lean_overlay").click(function() { 
-                     close_modal(modal_id);                    
+				$("#lean_overlay").click(function() {
+                     close_modal(modal_id);
                 });
-                
-                $(o.closeButton).click(function() { 
-                     close_modal(modal_id);                    
+
+                $(o.closeButton).click(function() {
+                     close_modal(modal_id);
                 });
-                         	
-              	var modal_height = $(modal_id).outerHeight();
-        	  	var modal_width = $(modal_id).outerWidth();
 
         		$('#lean_overlay').css({ 'display' : 'block', opacity : 0 });
 
         		$('#lean_overlay').fadeTo(200,o.overlay);
 
-        		$(modal_id).css({ 
-        		
+        		$(modal_id).css({
+
         			'display' : 'block',
-        			'position' : 'fixed',
         			'opacity' : 0,
         			'z-index': 11000,
-        			'left' : 50 + '%',
-        			'margin-left' : -(modal_width/2) + "px",
-        			'top' : o.top + "px"
-        		
         		});
 
         		$(modal_id).fadeTo(200,1);
 
                 e.preventDefault();
-                		
+
               	});
-             
+
             });
 
 			function close_modal(modal_id){
@@ -64,10 +55,10 @@
         		$("#lean_overlay").fadeOut(200);
 
         		$(modal_id).css({ 'display' : 'none' });
-			
+
 			}
-    
+
         }
     });
-     
+
 })(jQuery);


### PR DESCRIPTION
Minor tweaks to the help overlay CSS + JS to have it better fit the display at almost any screen size. Also makes it scrollable so that the content can be reached regardless of the help dialog length.

Previously, a part of the help dialog would stay hidden below the fold on default MBP screen resolution.

![screenshot 2015-10-25 11 18 12](https://cloud.githubusercontent.com/assets/299644/10714872/404cdfea-7b0a-11e5-94c1-fb53b493c736.png)
