### PR TITLE
Typing 'help' in the console opens up the cheatsheet

### DIFF
--- a/public/script/royrepl.js
+++ b/public/script/royrepl.js
@@ -107,6 +107,9 @@ define(["bacon","jq-console"], function(Bacon) {
       focus: function() {
         cs.Focus()
       },
+      help: function() {
+        sendToConsole(fmtValue("interactive help goes here"))  
+      },
       print: function(text) {
         sendToConsole(fmtValue(text))
       },

--- a/public/script/royrepl.js
+++ b/public/script/royrepl.js
@@ -108,7 +108,7 @@ define(["bacon","jq-console"], function(Bacon) {
         cs.Focus()
       },
       help: function() {
-        sendToConsole(fmtValue("interactive help goes here"))  
+        $("#help").click()
       },
       print: function(text) {
         sendToConsole(fmtValue(text))

--- a/public/script/turtle.roy
+++ b/public/script/turtle.roy
@@ -29,6 +29,7 @@ let clear = makeCallback(\() -> turtle.clear ())
 let wait seconds = (\callback -> setTimeout callback (seconds * 1000))
 let say text = makeCallback (\() -> speak text)
 let print = window.repl.print
+let help = window.repl.help
 let color c = makeCallback(\() -> turtle.color c)
 let background color = makeCallback(\() -> turtle.background color)
 let bg = background


### PR DESCRIPTION
Quite the minimum viable solution for #21. No repetition, no interactivity.

(Initially had esc key close the help too but Firefox had some funny 'Can't tokenise' issue once thereafter, so omitted that for now.)